### PR TITLE
Optimize mean T calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ pip install .
 This will install the necessary dependencies for the project, and allow you to
 run the code; the dependencies are specified in `pyproject.toml`.
 
+## Running the code
+
+```python
+import pycone
+
+cones, weather = pycone.preprocess.load_data()
+mean_t = pycone.analysis.calculate_mean_t(weather)
+```
+
 ## Development
 
 To pull in the development dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy",
+    "numpy>=1.21.6",
     "scipy",
     "matplotlib",
     "pandas",
@@ -59,6 +59,6 @@ select = [
 "__init__.py" = ["F401"]
 
 [project.optional-dependencies]
-dev = ["pre-commit", "ruff-lsp", "python-lsp-server", "pytest"]
+dev = ["pre-commit>=3.6.0", "ruff-lsp", "python-lsp-server", "pytest"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This calculation used to take a really long time because indexing into a `pd.DataFrame` with `.loc` is apparently a lot slower than indexing into numpy arrays.

- This PR pulls the relevant numpy arrays out of the `DataFrame` instances, resulting in a speedup of ~10 minutes -> ~30s on my machine. :rocket:
- I also updated the readme with a code snippet so people know how to run it.
- Bump the progress bar refresh rate for the mean T calculation to 30 Hz to keep up with the ultra speed