### PR TITLE
Fix a couple of issues with loading cone data

### DIFF
--- a/pycone/analysis.py
+++ b/pycone/analysis.py
@@ -418,7 +418,7 @@ def compute_correlation(
     # join the weather and ΔT data into a single dataframe
 
     gb = (
-        cones["site", "year", "cones"]
+        cones[["site", "year", "cones"]]
         .merge(
             delta_t,
             how="inner",

--- a/pycone/util.py
+++ b/pycone/util.py
@@ -11,6 +11,7 @@ DTYPES = {
     "duration": np.short,
     "site": np.short,
     "year": np.short,
+    "cones": int,
 }
 
 SITE_CODES = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,5 +99,6 @@ ignore = [
 [project.optional-dependencies]
 dev = ["pre-commit>=3.6.0", "ruff-lsp", "python-lsp-server", "pytest"]
 build = ["setuptools_scm", "meson-python", "pybind11", "build"]
+notebook = ["jupyterlab", "ipywidgets"]
 
 [tool.setuptools_scm]

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -42,52 +42,51 @@ def test_load_cone_crop(mock_read_excel):
     """Test that the cone crop can be loaded and preprocessed."""
     mock_read_excel.return_value = pd.DataFrame(
         {
-            "Code ": ["1ABAM_OR", "2ABCO_OR", "3ABCO_OR", "4ABLA_OR"],
-            "REF": [
+            "site": ["1ABAM_OR", "2ABCO_OR", "3ABCO_OR", "4ABLA_OR"],
+            "ref": [
                 "SCHULZE & FRANKLIN 2018; FRANKLIN ET AL 1974",
                 "SCHULZE & FRANKLIN 2019",
                 "SCHULZE & FRANKLIN 2019",
                 "SCHULZE & FRANKLIN 2019",
             ],
-            "SPECIES": [
+            "species": [
                 "ABIES AMABILIS",
                 "ABIES CONCOLOR",
                 "ABIES CONCOLOR",
                 "ABIES LASIOCARPA",
             ],
-            "GENUS": ["ABIES", "ABIES", "ABIES", "ABIES"],
-            "FAMILY": ["PINACEAE", "PINACEAE", "PINACEAE", "PINACEAE"],
-            "NRCS_GENUS": ["ABIES", "ABIES", "ABIES", "ABIES"],
-            "NRCS_SPECIES": ["ABAM", "ABCO", "ABCO", "ABLA"],
-            "SITE": ["SANTIAM PASS", "ASHLAND RNA", "WICKIUP SPRINGS", "SAND MOUNTAIN"],
-            "COUNTRY": ["USA", "USA", "USA", "USA"],
-            "STATE_PROVINCE": ["OR", "OR", "OR", "OR"],
-            "LATITUDE": [44.39085, 42.10711, 42.6058, 44.383333],
-            "LONGITUDE": [-121.8494, -122.69266, -122.2966, -121.921667],
-            "ELEVATION_m": [1446.1, 1400.0, 1479.0, 1421.5],
-            "STRTYR": [1962, 1981, 1981, 1959],
-            "ENDYR": [2002, 2017, 2017, 2019],
-            "Nyears": [41, 34, 33, 54],
-            "COMMENTS": [
+            "genus": ["ABIES", "ABIES", "ABIES", "ABIES"],
+            "family": ["PINACEAE", "PINACEAE", "PINACEAE", "PINACEAE"],
+            "nrcs_genus": ["ABIES", "ABIES", "ABIES", "ABIES"],
+            "nrcs_species": ["ABAM", "ABCO", "ABCO", "ABLA"],
+            "country": ["USA", "USA", "USA", "USA"],
+            "state_province": ["OR", "OR", "OR", "OR"],
+            "latitude": [44.39085, 42.10711, 42.6058, 44.383333],
+            "longitude": [-121.8494, -122.69266, -122.2966, -121.921667],
+            "elevation_m": [1446.1, 1400.0, 1479.0, 1421.5],
+            "strtyr": [1962, 1981, 1981, 1959],
+            "endyr": [2002, 2017, 2017, 2019],
+            "nyears": [41, 34, 33, 54],
+            "comments": [
                 "UPDATED FROM FRANKLIN 1968; UPDATED FROM FRANKLIN 1974",
                 "Andrews Forest LTER, initiated by Franklin in 64",
                 "Andrews Forest LTER, initiated by Franklin in 68",
                 "LARGER LTER DATASET REPLACES WOODWARD ET AL. 1994 DATA",
             ],
-            "Y1980": [6, "NA", "NA", 0],
-            "Y1981": [0, 35, 22, 1],
-            "Y1982": [21, 3, 0, 26],
-            "Y1983": [0, 0, 0, 0],
-            "Y1984": [0, 12, 0, 0],
-            "Y2013": ["NA", 0, 0, 0],
-            "Y2014": ["NA", 60, 0, 6],
+            "y1980": [6, pd.NA, pd.NA, 0],
+            "y1981": [0, 35, 22, 1],
+            "y1982": [21, 3, 0, 26],
+            "y1983": [0, 0, 0, 0],
+            "y1984": [0, 12, 0, 0],
+            "y2013": [pd.NA, 0, 0, 0],
+            "y2014": [pd.NA, 60, 0, 6],
         }
     )
 
     df = preprocess.load_cone_crop()
 
-    # The number of rows should be 4 sites * 7 years for the mock data above
-    assert len(df) == 28
+    # The number of rows should be ((4 sites * 7 years) - 4 nan values) for the mock data above
+    assert len(df) == 24
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes a few issues with loading cone data:

- Bad list of cone data columns in `compute_correlation`
- Wrong dtype of cone data columns: shared columns need to match with weather data
- Wrong column name: `code` in the cone data should have been `site`, so that it matches weather data
- Added a new set of optional dependencies for jupyterlab