### PR TITLE
Add support for cone crop year; add ParallelProcessProgressPool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,12 @@ ignore = [
     "D213", # Multiline summary second line
     "PD901", # Avoid using 'df' for pandas dataframes. Perfectly fine in functions with limited scope
     "ANN201", # Missing return type annotation for public function (makes no sense for NoneType return types...)
+    "ANN101", # Missing type annotation for `self`
+    "ANN204", # Missing return type annotation for special method
+    "ANN003", # Missing type annotation for `**kwargs`
+    "D105", # Missing docstring in magic method
+    "D203", # 1 blank line before after class docstring
+    "D204", # 1 blank line required after class docstring
 ]
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
This PR adds support for a crop year argument, which allows the user to correlate temperature differences between two years with a cone crop that was measured in _different_ year.

It also adds a `ParallelProcessProgressPool`, which groups together the three context managers I was using before to create a progress pool with managed memory for reporting progress of workers.