### PR TITLE
Add test coverage and coverage CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
 
 jobs:
-  run-tests:
+  tests:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -14,6 +16,22 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[dev]
-      - name: Run tests
+      - id: run-tests
+        name: Run tests
         run: |
-          pytest
+          # For some reason running in editable mode like you would normally do with pytest-cov
+          # doesn't work on the github CI runner. Instead, we forcibly tell pytest-cov to check
+          # coverage on the installed pycone code, then strip the path of the files in the
+          # coverage report using sed to avoid horizontal clutter.
+          pytest --cov=$(python -c 'import site; print(site.getsitepackages()[0])')/pycone/ .
+          {
+            echo 'COVERAGE<<EOF'
+            coverage report -m --format=markdown | sed -e s#/.*/site-packages/##g
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Comment with coverage report
+        run: gh pr comment $ISSUE --edit-last --body "$COMMENT" || gh pr comment $ISSUE --body "$COMMENT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.pull_request.number }}
+          COMMENT: ${{ steps.run-tests.outputs.COVERAGE }}

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,10 @@ project(
 py_mod = import('python')
 py = py_mod.find_installation()
 
-pybind11_dep = dependency('pybind11', version: '>=2.10.4')
+pybind11 = find_program('pybind11-config')
+pybind11_dep = declare_dependency(
+  include_directories: [run_command(['pybind11-config', '--includes'], check: true).stdout().split('-I')[-1].strip()]
+)
 
 includes = include_directories(
   [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,11 @@ ignore = [
 ]
 
 [project.optional-dependencies]
-dev = ["pre-commit>=3.6.0", "ruff-lsp", "python-lsp-server", "pytest"]
+dev = ["pre-commit>=3.6.0", "ruff-lsp", "python-lsp-server", "pytest", "pytest-cov"]
 build = ["setuptools_scm", "meson-python", "pybind11", "build"]
 notebook = ["jupyterlab", "ipywidgets"]
 
 [tool.setuptools_scm]
+
+[tool.coverage.run]
+omit = ["tests/*"]  # Don't bother measuring test coverage for tests themselves


### PR DESCRIPTION
This PR adds `pytest-cov` as a dependency to allow for test coverage reports to be made. Additionally, the `tests` workflow was modified to automatically report test coverage information on pull requests.