### PR TITLE
Added special handling for pine species

### DIFF
--- a/pycone/output.py
+++ b/pycone/output.py
@@ -16,6 +16,8 @@ def plot_correlation_duration_grids(
     figsize: tuple[int, int] | None = None,
     extent: tuple[int, int, int, int] | None = None,
     filename: str | None = "site_{}_correlations.svg",
+    delta_t_year_gap: int = 1,
+    crop_year_gap: int = 1,
 ) -> list[plt.Figure] | None:
     """Generate a grid of correlation plots.
 
@@ -45,6 +47,11 @@ def plot_correlation_duration_grids(
         Filename template to use for writing figures to disk. If None, a list of figures are
         returned. Otherwise, this must be a format string to save individual figures (one figure for
         each site)
+    delta_t_year_gap : int
+        Gap between years for which ΔT is calculated
+    crop_year_gap : int
+        Gap between the second year used for calculating ΔT and the year in which the cone crop is
+        correlated
 
     Returns
     -------
@@ -68,6 +75,8 @@ def plot_correlation_duration_grids(
                     "filename": filename.format(site) if filename is not None else None,
                     "task_id": task_id,
                     "worker_status": pe.worker_status,
+                    "delta_t_year_gap": delta_t_year_gap,
+                    "crop_year_gap": crop_year_gap,
                 },
             )
 
@@ -88,6 +97,8 @@ def plot_correlation_duration_grid(
     filename: str | None = None,
     task_id: int | None = None,
     worker_status: dict[int, Any] | None = None,
+    delta_t_year_gap: int = 1,
+    crop_year_gap: int = 1,
 ) -> plt.Figure | None:
     """Generate a single correlation/duration plot for all durations in the given dataset.
 
@@ -122,6 +133,11 @@ def plot_correlation_duration_grid(
     worker_status : dict[int, Any]
         Dictionary where worker status information can be written. This is a multiprocessing-safe
         object shared across all workers.
+    delta_t_year_gap : int
+        Gap between years for which ΔT is calculated
+    crop_year_gap : int
+        Gap between the second year used for calculating ΔT and the year in which the cone crop is
+        correlated
 
     Returns
     -------
@@ -198,8 +214,11 @@ def plot_correlation_duration_grid(
     )
 
     fig.suptitle(
-        r"$\rho_{\Delta T_{ij} N_k}$"
-        + f" Site: {util.code_to_site(site)}, $k = j+1 = i+2$",
+        (
+            r"$\rho_{\Delta T_{ij} N_k}$"
+            f" Site: {util.code_to_site(site)}, "
+            f"$k = j+{crop_year_gap} = i+{crop_year_gap+delta_t_year_gap}$"
+        ),
         fontsize="xx-large",
     )
 

--- a/pycone/run.py
+++ b/pycone/run.py
@@ -58,7 +58,20 @@ def get_data() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         )
         correlation = util.read_data(correlation_path)
     else:
-        correlation = analysis.compute_correlation_from_mean(mean_t, cones)
+        mean_t_pines, mean_t_other = util.split_pine_sites(mean_t)
+        cones_pines, cones_other = util.split_pine_sites(cones)
+
+        correlation_others = analysis.compute_correlation_from_mean(
+            mean_t_other, cones_other
+        )
+
+        # Pines have a 3 year reproductive cycle, so treat separately
+        correlation_pines = analysis.compute_correlation_from_mean(
+            mean_t_pines, cones_pines, crop_year_gap=2
+        )
+
+        correlation = pd.concat((correlation_others, correlation_pines))
+
         util.write_data(correlation, correlation_path)
 
     return cones, weather, mean_t, correlation


### PR DESCRIPTION
This PR adds special handling for pine species.

- `util.py` now has a function that can split a `pd.DataFrame` into pine sites and other sites
- `run.py` now treats pine species with `crop_year_gap=2` to match their reproductive cycles
- `output.py`: `plot_correlation_duration_grids` now accepts arguments for `delta_t_year_gap` and `crop_year_gap`, which are used to annotate the title of the graphs to indicate the relation between $i$, $j$, and $k$.