### PR TITLE
Add the ability to calculate other correlation types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.11.6
       - name: Install dependencies
         run: |
           pip install .[dev]

--- a/pycone/__main__.py
+++ b/pycone/__main__.py
@@ -1,4 +1,4 @@
 from . import run
 
 if __name__ == "__main__":
-    run.show_fft()
+    run.run_all_correlation_kinds()


### PR DESCRIPTION
This PR adds the ability to run other correlation types. Other changes:

- Updated the plots to use T0-T3 instead of i,j,k to denote years of interest
- Added axvlines to show phases of T1 on each plot. Kind of messy...
- Downgrade test CI to 3.11.6, pymc doesn't play nice with 3.12 yet...