### PR TITLE
Plot lines for P1-P3 were wrong direction; oops!

### DIFF
--- a/pycone/analysis.py
+++ b/pycone/analysis.py
@@ -356,6 +356,7 @@ def correlation(
             correlation
             site
             duration
+            group
     """
     with util.ParallelExecutor("[green]Calculating correlation:") as pe:
         for group in groups:
@@ -389,6 +390,7 @@ def correlation_group(
     delta_t_year_gap: int = 1,
     crop_year_gap: int = 1,
     kind: util.CorrelationType = util.CorrelationType.DEFAULT,
+    method: str = "pearson",
 ) -> pd.DataFrame:
     """Calculate the cone crop correlation from mean temperature data per-site for the given group.
 
@@ -418,6 +420,8 @@ def correlation_group(
         correlated
     kind: util.CorrelationType
         Correlation type to use
+    method : str
+        Method kwarg to pass pandas.DataFrame.corr
 
     Returns
     -------
@@ -470,7 +474,9 @@ def correlation_group(
             right_on=["site", "crop_year"],
         )
 
-        corr = compute_correlation_site_duration(dt_cone_df, duration, kind)
+        corr = compute_correlation_site_duration(
+            dt_cone_df, duration, kind, method=method
+        )
         if group is not None:
             corr["group"] = group.name
         results.append(corr)

--- a/pycone/output.py
+++ b/pycone/output.py
@@ -105,6 +105,7 @@ def plot_correlation_duration_grid(
     delta_t_year_gap: int = 1,
     crop_year_gap: int = 1,
     kind: util.CorrelationType | None = None,
+    method: str = "pearson",
 ) -> plt.Figure | None:
     """Generate a single correlation/duration plot for all durations in the given dataset.
 
@@ -146,6 +147,8 @@ def plot_correlation_duration_grid(
         correlated
     kind : util.CorrelationType
         Correlation type to use
+    method : str
+        Method kwarg to pass pandas.DataFrame.corr
 
     Returns
     -------
@@ -218,10 +221,10 @@ def plot_correlation_duration_grid(
             labels=["Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct"],
         )
 
-        axis.axvline(x=91, color="k")
-        axis.axvline(x=121, color="k")
-        axis.axvline(x=152, color="k")
-        axis.axvline(x=213, color="k")
+        axis.axhline(y=91, color="k")
+        axis.axhline(y=121, color="k")
+        axis.axhline(y=152, color="k")
+        axis.axhline(y=213, color="k")
 
         if ax_row == nrows - 1 and ax_col == ncols // 2:
             axis.set_xlabel(
@@ -244,11 +247,11 @@ def plot_correlation_duration_grid(
     cax = fig.add_axes([0.85, 0.03, 0.1, 0.005])
 
     if kind == util.CorrelationType.DEFAULT:
-        correlation_text = r"$\rho_{\Delta T N}$"
+        correlation_text = f"{method}" + r"$\rho_{\Delta T N}$"
     elif kind == util.CorrelationType.EXP_DT:
-        correlation_text = r"$\rho_{exp(\Delta T) N}$"
+        correlation_text = f"{method}" + r"$\rho_{exp(\Delta T) N}$"
     elif kind == util.CorrelationType.EXP_DT_OVER_N:
-        correlation_text = r"$\rho_{exp(\Delta T/N) N}$"
+        correlation_text = f"{method}" + r"$\rho_{exp(\Delta T/N) N}$"
     else:
         correlation_text = ""
 

--- a/pycone/run.py
+++ b/pycone/run.py
@@ -129,7 +129,10 @@ def compute_correlation(
     return corr
 
 
-def run_analysis(kind: util.CorrelationType = util.CorrelationType.DEFAULT):
+def run_analysis(
+    kind: util.CorrelationType = util.CorrelationType.DEFAULT,
+    method: str = "pearson",
+):
     """Run the pycone analysis for each site separately.
 
     This function will load the weather and cone data and do some preprocessing. The resulting
@@ -149,6 +152,8 @@ def run_analysis(kind: util.CorrelationType = util.CorrelationType.DEFAULT):
     ----------
     kind : util.CorrelationType
         Correlation type to use
+    method : str
+        Method kwarg to pass pandas.DataFrame.corr
     """
     cones = load_cones()
     weather = load_weather()
@@ -172,7 +177,7 @@ def run_analysis(kind: util.CorrelationType = util.CorrelationType.DEFAULT):
         mean_t=mean_t,
         cones=cones,
         groups=groups,
-        output=f"correlation_{kind.value}.csv",
+        output=f"correlation_{method}_{kind.value}.csv",
     )
 
     output.plot_correlation_duration_grids(
@@ -182,17 +187,22 @@ def run_analysis(kind: util.CorrelationType = util.CorrelationType.DEFAULT):
         ncols=12,
         figsize=(40, 60),
         extent=(50, 280, 50, 280),
-        filename="group_{}_correlations" + f"_{kind.value}.svg",
+        filename="group_{}_correlations" + f"_{method}_{kind.value}.svg",
     )
 
 
-def run_batch_analysis(kind: util.CorrelationType = util.CorrelationType.DEFAULT):
+def run_batch_analysis(
+    kind: util.CorrelationType = util.CorrelationType.DEFAULT,
+    method: str = "pearson",
+):
     """Run the pycone analysis, grouping the sites with the same species together.
 
     Parameters
     ----------
     kind : util.CorrelationType
         Correlation type to use
+    method : str
+        Method kwarg to pass pandas.DataFrame.corr
     """
     cones = load_cones()
     weather = load_weather()
@@ -212,13 +222,14 @@ def run_batch_analysis(kind: util.CorrelationType = util.CorrelationType.DEFAULT
                 crop_year_gap=util.get_crop_year_gap(site),
                 delta_t_year_gap=1,
                 kind=kind,
+                method=method,
             )
 
     correlation = compute_correlation(
         mean_t=mean_t,
         cones=cones,
         groups=list(groups.values()),
-        output=f"correlation_grouped_{kind.value}.csv",
+        output=f"correlation_{method}_grouped_{kind.value}.csv",
     )
 
     output.plot_correlation_duration_grids(
@@ -228,7 +239,7 @@ def run_batch_analysis(kind: util.CorrelationType = util.CorrelationType.DEFAULT
         ncols=12,
         figsize=(40, 60),
         extent=(50, 280, 50, 280),
-        filename="group_{}_correlations_grouped" + f"_{kind.value}.svg",
+        filename="group_{}_correlations_grouped" + f"_{method}_{kind.value}.svg",
     )
 
 
@@ -247,5 +258,6 @@ def run_all_correlation_kinds():
         util.CorrelationType.EXP_DT,
         util.CorrelationType.EXP_DT_OVER_N,
     ]:
-        run_analysis(kind=kind)
-        run_batch_analysis(kind=kind)
+        for method in ["pearson", "spearman"]:
+            run_analysis(kind=kind, method=method)
+            run_batch_analysis(kind=kind, method=method)


### PR DESCRIPTION
This PR fixes the annotations for P1-P3 on the plots. Previously they were oriented vertically, but they should have been horizontal (they correspond to features in T1, the second year of development).

Also, I added support for specifying the correlation method to use.